### PR TITLE
Fixed compilation error on `Report.swift` line 27

### DIFF
--- a/Sources/coherent-swift/Commands/Report.swift
+++ b/Sources/coherent-swift/Commands/Report.swift
@@ -24,7 +24,7 @@ final class Report: Command, IOOperations {
     // --------------
     // MARK: Configuration Properties
     @Key("-s", "--spec", description: "Use a yaml configuration file")
-    var specs: String
+    var specs: String?
     
     
     var configurationPath: String = "coherent-swift.yml"


### PR DESCRIPTION
@arthurpalves Fixed a compile error on `Apple Swift version 5.2.2 (swiftlang-1103.0.32.6 clang-1103.0.32.51)` which `specs` variable was not optional, and it must be when using `if let` statement.