### PR TITLE
Fix filename processing if source folder is referenced as './'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+### 0.5.1
+- fix: fail to on 'init' command if not installed through make/brew/mint ([#35](https://github.com/arthurpalves/coherent-swift/pull/35)) via [@arthurpalves](https://github.com/arthurpalves)
+

--- a/Sources/coherent-swift/Helpers/IO/IOOperations.swift
+++ b/Sources/coherent-swift/Helpers/IO/IOOperations.swift
@@ -144,7 +144,7 @@ extension IOOperations {
     
     private func processFilePath(filename: String, sourcePath: String) -> String {
         var filepath = filename
-        if filepath.contains(sourcePath) {
+        if sourcePath.count > 2, filepath.contains(sourcePath) {
             filepath = filepath.replacingOccurrences(of: sourcePath, with: "")
             filepath = filepath.starts(with: "/") ? String(filepath.dropFirst()) : filepath
         }

--- a/Sources/coherent-swift/Helpers/IO/IOOperations.swift
+++ b/Sources/coherent-swift/Helpers/IO/IOOperations.swift
@@ -108,6 +108,10 @@ extension IOOperations {
                         fileAmount += 1
                     }
                 }
+            } else {
+                self.logger.logDebug("⚠️  Ignoring: ",
+                                item: "\(filename) - Not a .swift file format",
+                                color: .purple)
             }
         }
         

--- a/Sources/coherent-swift/main.swift
+++ b/Sources/coherent-swift/main.swift
@@ -3,7 +3,7 @@ import SwiftCLI
 
 let cli = CLI(
     name: "coherent-swift",
-    version: "0.5.0",
+    version: "0.5.2",
     description: "A command-line tool to analyze and report Swift code cohesion"
 )
 


### PR DESCRIPTION
Fix filename processing if source folder is referenced as './'. resolves #36