### PR TITLE
Downgrade Swift version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.2
 
 import PackageDescription
 


### PR DESCRIPTION
hotfix: downgrade to swift 5.3 as Github's mac runner doesn't have 5.3 installed yet