### PR TITLE
Fix compile time issue with Xcode 13.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(
 			name: "SwiftSyntax",
             url: "https://github.com/apple/swift-syntax.git",
-            .exact("0.50400.0")
+            .exact("0.50500.0")
         )
     ],
     targets: [


### PR DESCRIPTION
This pull requests bumps the `SwiftSyntax` version to `0.50500.0`. This allows building the tool again with Xcode 13.2.1.

Fixes #54 