### PR TITLE
Align template with latest configuration file format

### DIFF
--- a/Templates/coherent-swift-template.yml
+++ b/Templates/coherent-swift-template.yml
@@ -8,7 +8,8 @@
 # NOTE: If run with --diffs, it will only scan files in this source folder but which
 # content's have been modified
 
-source: ./Sources/
+sources:
+  - ./Sources/
 
 # minimum_threshold
 # It will validate the definition's and overall cohesion against this minimum threshold.


### PR DESCRIPTION
Right now, the configuration file created by `coherent-swift init` is not compatible with the format `coherent-swift report` expects. This pull requests aligns the two again.